### PR TITLE
Fixed authentication bug

### DIFF
--- a/examples/WalletExample/Program.cs
+++ b/examples/WalletExample/Program.cs
@@ -266,8 +266,8 @@ namespace WalletExample
             string password = Console.ReadLine();
 
             var response = await AccountActions.Login(username, password);
-            GlobalConfig.instance.DefaultHeaders.Add("Authorization", "Bearer " + response.Jwt); // Set the JWT token for authentication
-            //TODO: GlobalConfig.instance.AccessToken = response.Jwt; // Switch to this after fixing the Openapi specification authentication mishaps hotfix
+            //GlobalConfig.instance.DefaultHeaders.Add("Authorization", "Bearer " + response.Jwt); // Set the JWT token for authentication
+            GlobalConfig.instance.AccessToken = response.Jwt; // Switch to this after fixing the Openapi specification authentication mishaps hotfix
             //Here we use the username variable that is used for WWW-Authenticate to store the username
             GlobalConfig.instance.Username = username; //Store Username for later use
 

--- a/sdk/src/Neuron.Agent/Api/CryptoApi.cs.bak
+++ b/sdk/src/Neuron.Agent/Api/CryptoApi.cs.bak
@@ -656,7 +656,6 @@ namespace Neuron.Agent.Api
             localVarRequestOptions.Operation = "CryptoApi.GetPublicKey";
             localVarRequestOptions.OperationIndex = operationIndex;
 
-            // authentication (BearerAuth) required
             // bearer authentication required
             if (!string.IsNullOrEmpty(this.Configuration.AccessToken) && !localVarRequestOptions.HeaderParameters.ContainsKey("Authorization"))
             {


### PR DESCRIPTION
Some endpoint missed the Required authentication in the specification
The changes made to the specification are now reflected in the SDK

Now setting Configuration.AccessToken is working properly

Closes #7 